### PR TITLE
Require active_support in spec_helper.rb.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'factory_girl'
+require 'active_support'
 require 'active_support/core_ext'
 
 FactoryGirl.find_definitions


### PR DESCRIPTION
Without this modifiction, I get an error when running `rake`. I also believe that this is the [documented](https://guides.rubyonrails.org/active_support_core_extensions.html#stand-alone-active-support) way to require active_support extensions.